### PR TITLE
Update TWE VEP config to v1.1.24 and artemis expiry date to 4 months

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dias_TWE_config_GRCh37_v3.2.2.json
+# dias_TWE_config_GRCh37_v3.2.3.json
 
 This repo contains a JSON config file which is used with eggd_dias_batch to specify inputs for running the Dias pipeline for TWE data.
 
@@ -32,4 +32,4 @@ Dynamic files:
 | genes2transcripts | **240402_g2t.tsv** | `file-Gj770X8433Gb506pjq1PxXG9` |
 | panel_dump for eggd_optimised_filtering | **241030_panelapp_dump.json** | `file-GvVg3qj4Y54jBF8bgX62gkfQ` |
 | exons_with_symbols for eggd_athena | **GCF_000001405.25_GRCh37.p13_genomic.symbols.exon_5bp_v2.0.0.tsv** | `file-GF611Z8433Gf99pBPbJkV7bq` |
-| twe_vep_config for SNV reports | **twe_vep_config_v1.1.23.json** | `file-GxVGJQj4j4fbF9V218bG8KK3` |
+| twe_vep_config for SNV reports | **twe_vep_config_v1.1.24.json** | `file-Gy92zFQ4j4fjvjFQBq277QB6` |

--- a/dias_TWE_config_GRCh37_v3.2.3.json
+++ b/dias_TWE_config_GRCh37_v3.2.3.json
@@ -1,6 +1,6 @@
 {
     "assay": "TWE",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "artemis_app_id": "app-GkbJ7p0463bjk9VKv3x8G5F8",
     "snv_report_workflow_id": "workflow-GkbJY284FpfgqF8ggz57fVY2",
     "reference_files": {
@@ -32,7 +32,7 @@
                 "stage-rpt_vep.config_file": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
-                        "id": "file-GxVGJQj4j4fbF9V218bG8KK3"
+                        "id": "file-Gy92zFQ4j4fjvjFQBq277QB6"
                     }
                 },
                 "stage-rpt_vep.vcf": {
@@ -78,7 +78,7 @@
         },
         "artemis": {
             "inputs": {
-                "url_duration": 15811200,
+                "url_duration": 10510000,
                 "capture_bed": {
                     "$dnanexus_link": {
                         "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",


### PR DESCRIPTION
Changes:

- update README
- update config version to v3.2.3
- update TWE VEP config file to v1.1.24
- update url_duration of artemis to 10510000 second (4 months)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/egg4_dias_TWE_config/72)
<!-- Reviewable:end -->
